### PR TITLE
Fix JWT sign in tokens for user in multiple roles

### DIFF
--- a/src/NetCoreApp/Identity/Bearer/src/BearerSignInManaging/BearerSignInManager{UserType,BearerTokenType}.cs
+++ b/src/NetCoreApp/Identity/Bearer/src/BearerSignInManaging/BearerSignInManager{UserType,BearerTokenType}.cs
@@ -125,15 +125,16 @@ namespace Teronis.Identity.BearerSignInManaging
             var accessTokenDescriptor = signInManagerOptions.CreateAccessTokenDescriptor();
 
             // Used by authentication middleware.
-            accessTokenDescriptor.Claims.Add(ClaimTypes.NameIdentifier, user.Id);
-            accessTokenDescriptor.Claims.Add(ClaimTypes.Name, user.UserName);
+            accessTokenDescriptor.Subject = new ClaimsIdentity();
+            accessTokenDescriptor.Subject.AddClaim(new Claim(ClaimTypes.NameIdentifier, user.Id));
+            accessTokenDescriptor.Subject.AddClaim(new Claim(ClaimTypes.Name, user.UserName));
 
             try {
                 var roles = await userManager.GetRolesAsync(user);
 
                 if (roles != null) {
                     foreach (var role in roles) {
-                        accessTokenDescriptor.Claims.Add(ClaimTypes.Role, role);
+                        accessTokenDescriptor.Subject.AddClaim(new Claim(ClaimTypes.Role, role));
                     }
                 }
 

--- a/src/NetCoreApp/Identity/Bearer/src/BearerSignInManaging/BearerSignInManager{UserType,BearerTokenType}.cs
+++ b/src/NetCoreApp/Identity/Bearer/src/BearerSignInManaging/BearerSignInManager{UserType,BearerTokenType}.cs
@@ -125,7 +125,7 @@ namespace Teronis.Identity.BearerSignInManaging
             var accessTokenDescriptor = signInManagerOptions.CreateAccessTokenDescriptor();
 
             // Used by authentication middleware.
-            accessTokenDescriptor.Subject = new ClaimsIdentity();
+            accessTokenDescriptor.Subject = accessTokenDescriptor.Subject ?? new ClaimsIdentity();
             accessTokenDescriptor.Subject.AddClaim(new Claim(ClaimTypes.NameIdentifier, user.Id));
             accessTokenDescriptor.Subject.AddClaim(new Claim(ClaimTypes.Name, user.UserName));
 

--- a/src/NetCoreApp/Identity/Bearer/src/Extensions/SecurityTokenDescriptorExtensions.cs
+++ b/src/NetCoreApp/Identity/Bearer/src/Extensions/SecurityTokenDescriptorExtensions.cs
@@ -34,7 +34,7 @@ namespace Teronis.Identity.Extensions
 
             if (!ReferenceEquals(subject, null)) {
                 /// Add missing claims. (see comment in <see cref="SecurityTokenDescriptor.Claims"/>)
-                tokenDescriptor.Subject.AddClaims(subject.Claims.Where(x => !subject.HasClaim(x.Type, x.Value)));
+                tokenDescriptor.Subject.AddClaims(subject.Claims);
             }
 
             if (!ReferenceEquals(tokenDescriptor.Claims, null)) {


### PR DESCRIPTION
I was running into exceptions when I tried to create access tokens for users in multiple roles. The `accessTokenDescriptor.Claims` is a dictionary which doesn ot support duplicated keys.

This PR fixes this by inserting the claims in the `accessTokenDescriptor.Subject`  directly. Now I can request access tokens with users in multiple roles without any issues.

This also fixes a bug in _SecurityTokenDescriptorExtensions.cs_ where no claims from the subject are moved over.
