### PR TITLE
Create usage example for Teronis.MSBuild.Packaging.ProjectBuildInPackage

### DIFF
--- a/src/MSBuild/Packaging/ProjectBuildInPackage/README.md
+++ b/src/MSBuild/Packaging/ProjectBuildInPackage/README.md
@@ -1,0 +1,20 @@
+# Teronis.MSBuild.Packaging.ProjectBuildInPackage
+
+## Usage
+* Install ```Teronis.MSBuild.Packaging.ProjectBuildInPackage``` nuget package, ie. ```Install-Package Teronis.MSBuild.Packaging.ProjectBuildInPackage```
+* Modify the project that will be packed: add ```PrivateAssets="all"``` property into each ```ProjectReference``` item that is to be included into the nuget package
+* Pack/publish, ie. using Visual Studio's "Publish" component
+
+### Example
+Before
+```
+  <ItemGroup>
+    <ProjectReference Include="..\SomeReallyGoodProject\SomeReallyGoodProject.csproj" />
+  </ItemGroup>
+```
+After
+```
+  <ItemGroup>
+    <ProjectReference Include="..\SomeReallyGoodProject\SomeReallyGoodProject.csproj" PrivateAssets="all" />
+  </ItemGroup>
+```


### PR DESCRIPTION
The original usage for this package is described deep in this ticket https://github.com/NuGet/Home/issues/3891 which has at this moment over 250 comments.

It'd be easier to have a simple usage description for people that don't really want to read the whole thread, or found this nuget package from a different source, ie. from this stackoverflow thread: https://stackoverflow.com/questions/40396161/include-all-dependencies-using-dotnet-pack